### PR TITLE
Add the Typesafe resolver globally

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,7 @@ lazy val root = (project in file("."))
     test in Test := {
       val _ = (g8Test in Test).toTask("").value
     },
-    scriptedLaunchOpts ++= List("-Xms1024m", "-Xmx1024m", "-XX:ReservedCodeCacheSize=128m", "-XX:MaxPermSize=256m", "-Xss2m", "-Dfile.encoding=UTF-8"),
-    resolvers += Resolver.url("typesafe", url("http://repo.typesafe.com/typesafe/ivy-releases/"))(Resolver.ivyStylePatterns)
+    scriptedLaunchOpts ++= List("-Xms1024m", "-Xmx1024m", "-XX:ReservedCodeCacheSize=128m", "-XX:MaxPermSize=256m", "-Xss2m", "-Dfile.encoding=UTF-8")
   )
 
 // Documentation for this project:
@@ -16,3 +15,5 @@ lazy val root = (project in file("."))
 //    open docs/target/paradox/site/main/index.html
 lazy val docs = (project in file("docs"))
   .enablePlugins(ParadoxPlugin)
+
+resolvers in ThisBuild += Resolver.url("typesafe", url("http://repo.typesafe.com/typesafe/ivy-releases/"))(Resolver.ivyStylePatterns)


### PR DESCRIPTION
This is needed for both the root and docs build.

## Purpose

This fixes the documentation build when you don't have the sbt-launch artifact already cached.

## References

References #14.